### PR TITLE
Rework caching to reduce memory usage

### DIFF
--- a/BeatmapDifficultyLookupCache/Controllers/CacheController.cs
+++ b/BeatmapDifficultyLookupCache/Controllers/CacheController.cs
@@ -17,7 +17,7 @@ namespace BeatmapDifficultyLookupCache.Controllers
         }
 
         [HttpDelete]
-        public void Delete([FromQuery(Name = "beatmap_id")] int? beatmapId, [FromQuery(Name = "ruleset_id")] int? rulesetId)
-            => cache.Purge(beatmapId, rulesetId);
+        public void Delete([FromQuery(Name = "beatmap_id")] int beatmapId)
+            => cache.Purge(beatmapId);
     }
 }

--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -2,17 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Primitives;
 using osu.Framework.IO.Network;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
@@ -25,109 +21,94 @@ namespace BeatmapDifficultyLookupCache
     public class DifficultyCache
     {
         private static readonly List<Ruleset> available_rulesets = getRulesets();
+        private static readonly DifficultyAttributes empty_attributes = new DifficultyAttributes(Array.Empty<Mod>(), Array.Empty<Skill>(), -1);
 
-        private readonly ConcurrentDictionary<DifficultyRequest, CancellationTokenSource> requestExpirationSources = new ConcurrentDictionary<DifficultyRequest, CancellationTokenSource>();
-        private readonly ConcurrentDictionary<int, CancellationTokenSource> beatmapExpirationSources = new ConcurrentDictionary<int, CancellationTokenSource>();
-
+        private readonly Dictionary<DifficultyRequest, Task<DifficultyAttributes>> attributesCache = new Dictionary<DifficultyRequest, Task<DifficultyAttributes>>();
         private readonly IConfiguration config;
-        private readonly IMemoryCache cache;
         private readonly ILogger logger;
 
-        public DifficultyCache(IConfiguration config, IMemoryCache cache, ILogger<DifficultyCache> logger)
+        public DifficultyCache(IConfiguration config, ILogger<DifficultyCache> logger)
         {
             this.config = config;
-            this.cache = cache;
             this.logger = logger;
         }
 
-        private static readonly DifficultyAttributes empty_attributes = new DifficultyAttributes(Array.Empty<Mod>(), Array.Empty<Skill>(), -1);
-
-        public async Task<DifficultyAttributes> GetDifficulty(DifficultyRequest request)
+        public Task<DifficultyAttributes> GetDifficulty(DifficultyRequest request)
         {
             if (request.BeatmapId == 0)
-                return empty_attributes;
+                return Task.FromResult(empty_attributes);
 
-            return await cache.GetOrCreateAsync(request, async entry =>
+            Task<DifficultyAttributes>? task;
+
+            lock (attributesCache)
             {
-                logger.LogInformation("Computing difficulty (beatmap: {BeatmapId}, ruleset: {RulesetId}, mods: {Mods})",
-                    request.BeatmapId,
-                    request.RulesetId,
-                    request.Mods.Select(m => m.ToString()));
-
-                var requestExpirationSource = requestExpirationSources[request] = new CancellationTokenSource();
-
-                entry.SetPriority(CacheItemPriority.Normal);
-                entry.AddExpirationToken(new CancellationChangeToken(requestExpirationSource.Token));
-
-                try
+                if (!attributesCache.TryGetValue(request, out task))
                 {
-                    var ruleset = available_rulesets.First(r => r.RulesetInfo.ID == request.RulesetId);
-                    var mods = request.Mods.Select(m => m.ToMod(ruleset)).ToArray();
-                    var beatmap = await getBeatmap(request.BeatmapId);
+                    attributesCache[request] = task = Task.Run(async () =>
+                    {
+                        // Trim a few mods which are invalid.
+                        var apiMods = request.GetMods()
+                                             .Where(m => !string.IsNullOrWhiteSpace(m.Acronym) && m.Acronym.ToUpperInvariant() != "SCOREV2")
+                                             .ToArray();
 
-                    var difficultyCalculator = ruleset.CreateDifficultyCalculator(beatmap);
-                    return difficultyCalculator.Calculate(mods);
+                        logger.LogInformation("Computing difficulty (beatmap: {BeatmapId}, ruleset: {RulesetId}, mods: {Mods})",
+                            request.BeatmapId,
+                            request.RulesetId,
+                            apiMods.Select(m => m.ToString()));
+
+                        try
+                        {
+                            var ruleset = available_rulesets.First(r => r.RulesetInfo.ID == request.RulesetId);
+                            var mods = apiMods.Select(m => m.ToMod(ruleset)).ToArray();
+                            var beatmap = await getBeatmap(request.BeatmapId);
+
+                            var difficultyCalculator = ruleset.CreateDifficultyCalculator(beatmap);
+                            var attributes = difficultyCalculator.Calculate(mods);
+
+                            // Trim a few members which we don't consume and only take up RAM.
+                            attributes.Skills = Array.Empty<Skill>();
+                            attributes.Mods = Array.Empty<Mod>();
+
+                            return attributes;
+                        }
+                        catch (Exception e)
+                        {
+                            logger.LogWarning("Request failed with \"{Message}\"", e.Message);
+                            return empty_attributes;
+                        }
+                    });
                 }
-                catch (Exception e)
-                {
-                    entry.SetSlidingExpiration(TimeSpan.FromDays(1));
-                    logger.LogWarning($"Request failed with \"{e.Message}\"");
-                    return empty_attributes;
-                }
-            });
+            }
+
+            return task;
         }
 
         public void Purge(int? beatmapId, int? rulesetId)
         {
             logger.LogInformation("Purging (beatmap: {BeatmapId}, ruleset: {RulesetId})", beatmapId, rulesetId);
 
-            foreach (var (req, source) in requestExpirationSources)
+            lock (attributesCache)
             {
-                if (beatmapId != null && req.BeatmapId != beatmapId)
-                    continue;
-
-                if (rulesetId != null && req.RulesetId != rulesetId)
-                    continue;
-
-                source.Cancel();
-            }
-
-            if (beatmapId.HasValue)
-            {
-                if (beatmapExpirationSources.TryGetValue(beatmapId.Value, out var source))
-                    source.Cancel();
-            }
-            else
-            {
-                foreach (var (_, source) in beatmapExpirationSources)
-                    source.Cancel();
+                foreach (var req in attributesCache.Keys.ToArray())
+                    attributesCache.Remove(req);
             }
         }
 
-        private Task<WorkingBeatmap> getBeatmap(int beatmapId)
+        private async Task<WorkingBeatmap> getBeatmap(int beatmapId)
         {
-            return cache.GetOrCreateAsync<WorkingBeatmap>($"{beatmapId}.osu", async entry =>
+            logger.LogInformation("Downloading beatmap ({BeatmapId})", beatmapId);
+
+            var req = new WebRequest(string.Format(config["Beatmaps:DownloadPath"], beatmapId))
             {
-                logger.LogInformation("Downloading beatmap ({BeatmapId})", beatmapId);
+                AllowInsecureRequests = true
+            };
 
-                var beatmapExpirationSource = beatmapExpirationSources[beatmapId] = new CancellationTokenSource();
+            await req.PerformAsync();
 
-                entry.SetPriority(CacheItemPriority.Low);
-                entry.SetSlidingExpiration(TimeSpan.FromMinutes(1));
-                entry.AddExpirationToken(new CancellationChangeToken(beatmapExpirationSource.Token));
+            if (req.ResponseStream.Length == 0)
+                throw new Exception($"Retrieved zero-length beatmap ({beatmapId})!");
 
-                var req = new WebRequest(string.Format(config["Beatmaps:DownloadPath"], beatmapId))
-                {
-                    AllowInsecureRequests = true
-                };
-
-                await req.PerformAsync(beatmapExpirationSource.Token);
-
-                if (req.ResponseStream.Length == 0)
-                    throw new Exception($"Retrieved zero-length beatmap ({beatmapId})!");
-
-                return new LoaderWorkingBeatmap(req.ResponseStream);
-            });
+            return new LoaderWorkingBeatmap(req.ResponseStream);
         }
 
         private static List<Ruleset> getRulesets()

--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -46,10 +46,7 @@ namespace BeatmapDifficultyLookupCache
                 {
                     attributesCache[request] = task = Task.Run(async () =>
                     {
-                        // Trim a few mods which are invalid.
-                        var apiMods = request.GetMods()
-                                             .Where(m => !string.IsNullOrWhiteSpace(m.Acronym) && m.Acronym.ToUpperInvariant() != "SCOREV2")
-                                             .ToArray();
+                        var apiMods = request.GetMods();
 
                         logger.LogInformation("Computing difficulty (beatmap: {BeatmapId}, ruleset: {RulesetId}, mods: {Mods})",
                             request.BeatmapId,

--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -80,14 +80,17 @@ namespace BeatmapDifficultyLookupCache
             return task;
         }
 
-        public void Purge(int? beatmapId, int? rulesetId)
+        public void Purge(int beatmapId)
         {
-            logger.LogInformation("Purging (beatmap: {BeatmapId}, ruleset: {RulesetId})", beatmapId, rulesetId);
+            logger.LogInformation("Purging (beatmap: {BeatmapId})", beatmapId);
 
             lock (attributesCache)
             {
                 foreach (var req in attributesCache.Keys.ToArray())
-                    attributesCache.Remove(req);
+                {
+                    if (req.BeatmapId == beatmapId)
+                        attributesCache.Remove(req);
+                }
             }
         }
 

--- a/BeatmapDifficultyLookupCache/DifficultyRequest.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyRequest.cs
@@ -21,7 +21,33 @@ namespace BeatmapDifficultyLookupCache
         [JsonProperty("mods")]
         public JArray? Mods { get; init; }
 
-        public IEnumerable<APIMod> GetMods() => Mods?.ToObject<APIMod[]>()?.OrderBy(m => m.Acronym).ToArray() ?? Array.Empty<APIMod>();
+        public List<APIMod> GetMods()
+        {
+            var apiMods = new List<APIMod>(Mods?.ToObject<APIMod[]>()?.OrderBy(m => m.Acronym).ToArray() ?? Array.Empty<APIMod>());
+
+            // Hacks for some stable-specific mods.
+            apiMods.RemoveAll(m =>
+            {
+                string? acronym = m.Acronym?.ToUpper();
+
+                if (string.IsNullOrWhiteSpace(acronym))
+                    return true;
+
+                if (acronym is "SCOREV2" or "CINEMA" or "RELAX" or "AUTO")
+                    return true;
+
+                return false;
+            });
+
+            // Stable provides an unexpected acronym for dual stages.
+            foreach (var m in apiMods)
+            {
+                if (m.Acronym == "2P")
+                    m.Acronym = "DS";
+            }
+
+            return apiMods;
+        }
 
         public bool Equals(DifficultyRequest? other)
         {

--- a/BeatmapDifficultyLookupCache/DifficultyRequest.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyRequest.cs
@@ -33,8 +33,14 @@ namespace BeatmapDifficultyLookupCache
                 if (string.IsNullOrWhiteSpace(acronym))
                     return true;
 
-                if (acronym is "SCOREV2" or "CINEMA" or "RELAX" or "AUTO")
-                    return true;
+                switch (acronym)
+                {
+                    case "SCOREV2":
+                    case "CINEMA":
+                    case "RELAX":
+                    case "AUTO":
+                        return true;
+                }
 
                 return false;
             });

--- a/README.md
+++ b/README.md
@@ -32,7 +32,5 @@ curl -X POST -H "Content-Type: application/json" \
 
 ```
 curl -X DELETE \
-    http://localhost:80/cache?beatmap_id=129891&ruleset_id=0
+    http://localhost:80/cache?beatmap_id=129891
 ```
-
-`beatmap_id` and `ruleset_id` are optional.


### PR DESCRIPTION
In my testing, 1M `DifficultyRequest` + `DifficultyAttributes` objects now takes up ~300MB RAM.

Let's see how this goes and assess whether an `IMemoryCache` is still required afterwards?

- Removes beatmap cache.
- Uses local dictionary cache for the difficulty attributes/requests.
- Fixes `ScoreV2` and a few other stable-specific acronyms throwing exceptions, though combinations containing these mod will still be reprocessed for the time being (should be fairly rare cases).
- Reworks `DifficultyRequest` to reduce size by storing raw `JArray` instead of `APIMod` objects.