### PR TITLE
Update to net6.0 and bump osu dependencies

### DIFF
--- a/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
+++ b/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.0.90" />
+      <PackageReference Include="Dapper" Version="2.0.123" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
-      <PackageReference Include="MySqlConnector" Version="1.3.13" />
-      <PackageReference Include="ppy.osu.Game" Version="2021.1111.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1111.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1111.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1111.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1111.0" />
+      <PackageReference Include="MySqlConnector" Version="2.1.6" />
+      <PackageReference Include="ppy.osu.Game" Version="2022.205.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.205.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.205.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.205.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.205.0" />
     </ItemGroup>
 
 </Project>

--- a/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
+++ b/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.90" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.10" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
       <PackageReference Include="MySqlConnector" Version="1.3.13" />
       <PackageReference Include="ppy.osu.Game" Version="2021.1111.0" />
       <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1111.0" />

--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -17,7 +17,6 @@ using osu.Game.Beatmaps.Legacy;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
-using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
 
 namespace BeatmapDifficultyLookupCache
@@ -25,7 +24,7 @@ namespace BeatmapDifficultyLookupCache
     public class DifficultyCache
     {
         private static readonly List<Ruleset> available_rulesets = getRulesets();
-        private static readonly DifficultyAttributes empty_attributes = new DifficultyAttributes(Array.Empty<Mod>(), Array.Empty<Skill>(), -1);
+        private static readonly DifficultyAttributes empty_attributes = new DifficultyAttributes(Array.Empty<Mod>(), -1);
 
         private readonly Dictionary<DifficultyRequest, Task<DifficultyAttributes>> attributesCache = new Dictionary<DifficultyRequest, Task<DifficultyAttributes>>();
         private readonly IConfiguration config;
@@ -93,7 +92,7 @@ namespace BeatmapDifficultyLookupCache
 
                         try
                         {
-                            var ruleset = available_rulesets.First(r => r.RulesetInfo.ID == request.RulesetId);
+                            var ruleset = available_rulesets.First(r => r.RulesetInfo.OnlineID == request.RulesetId);
                             var mods = apiMods.Select(m => m.ToMod(ruleset)).ToArray();
                             var beatmap = await getBeatmap(request.BeatmapId);
 
@@ -101,7 +100,6 @@ namespace BeatmapDifficultyLookupCache
                             var attributes = difficultyCalculator.Calculate(mods);
 
                             // Trim a few members which we don't consume and only take up RAM.
-                            attributes.Skills = Array.Empty<Skill>();
                             attributes.Mods = Array.Empty<Mod>();
 
                             return attributes;

--- a/BeatmapDifficultyLookupCache/LoaderWorkingBeatmap.cs
+++ b/BeatmapDifficultyLookupCache/LoaderWorkingBeatmap.cs
@@ -7,10 +7,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
-using osu.Game.Rulesets.Catch;
-using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Taiko;
 using osu.Game.Skinning;
 
 namespace BeatmapDifficultyLookupCache
@@ -34,25 +30,6 @@ namespace BeatmapDifficultyLookupCache
             : base(beatmap.BeatmapInfo, null)
         {
             this.beatmap = beatmap;
-
-            switch (beatmap.BeatmapInfo.RulesetID)
-            {
-                case 0:
-                    beatmap.BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
-                    break;
-
-                case 1:
-                    beatmap.BeatmapInfo.Ruleset = new TaikoRuleset().RulesetInfo;
-                    break;
-
-                case 2:
-                    beatmap.BeatmapInfo.Ruleset = new CatchRuleset().RulesetInfo;
-                    break;
-
-                case 3:
-                    beatmap.BeatmapInfo.Ruleset = new ManiaRuleset().RulesetInfo;
-                    break;
-            }
         }
 
         protected override IBeatmap GetBeatmap() => beatmap;

--- a/BeatmapDifficultyLookupCache/LoaderWorkingBeatmap.cs
+++ b/BeatmapDifficultyLookupCache/LoaderWorkingBeatmap.cs
@@ -7,6 +7,10 @@ using osu.Framework.Graphics.Textures;
 using osu.Game.Beatmaps;
 using osu.Game.Beatmaps.Formats;
 using osu.Game.IO;
+using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Taiko;
 using osu.Game.Skinning;
 
 namespace BeatmapDifficultyLookupCache
@@ -30,6 +34,25 @@ namespace BeatmapDifficultyLookupCache
             : base(beatmap.BeatmapInfo, null)
         {
             this.beatmap = beatmap;
+
+            switch (beatmap.BeatmapInfo.Ruleset.OnlineID)
+            {
+                case 0:
+                    beatmap.BeatmapInfo.Ruleset = new OsuRuleset().RulesetInfo;
+                    break;
+
+                case 1:
+                    beatmap.BeatmapInfo.Ruleset = new TaikoRuleset().RulesetInfo;
+                    break;
+
+                case 2:
+                    beatmap.BeatmapInfo.Ruleset = new CatchRuleset().RulesetInfo;
+                    break;
+
+                case 3:
+                    beatmap.BeatmapInfo.Ruleset = new ManiaRuleset().RulesetInfo;
+                    break;
+            }
         }
 
         protected override IBeatmap GetBeatmap() => beatmap;


### PR DESCRIPTION
@nanaya pointed out that the return values were camel cased instead of snake cased for the attributes responses. Turns out this is because the `osu.Game` version is dated and doesn't have the recently added `JsonProperty` specs yet.

Note that this won't affect existing osu-stable usage since it only uses the `RatingsController` endpoint.

Sample output:

```sh
curl "http://localhost:5002/attributes" -X POST -H "Content-Type: application/json" -d '{"beatmap_id":88}'
```

```json
{"star_rating":2.695924307598852,"max_combo":485,"aim_difficulty":1.4480048472775635,"speed_difficulty":1.088390390637992,"flashlight_difficulty":0.5967258807452882,"slider_factor":0.9606732787052947,"approach_rate":5.0,"overall_difficulty":5.0}⏎
```

This will also bring in some newer changes to diffcalc, which is something to be aware of, but will also not affect our usage as I will be deploying this using the database reader changes I have on my other branch.