### PR TITLE
Fully populate attributes when using database

### DIFF
--- a/BeatmapDifficultyLookupCache.sln.DotSettings
+++ b/BeatmapDifficultyLookupCache.sln.DotSettings
@@ -132,6 +132,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PossibleMultipleEnumeration/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PrivateVariableCanBeMadeReadonly/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=PublicConstructorInAbstractClass/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAnonymousTypePropertyName/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArgumentDefaultValue/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantArrayCreationExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantAttributeParentheses/@EntryIndexedValue">WARNING</s:String>

--- a/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
+++ b/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.0.123" />
+      <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
       <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
       <PackageReference Include="MySqlConnector" Version="2.1.6" />
       <PackageReference Include="ppy.osu.Game" Version="2022.205.0" />

--- a/BeatmapDifficultyLookupCache/Database.cs
+++ b/BeatmapDifficultyLookupCache/Database.cs
@@ -13,8 +13,9 @@ namespace BeatmapDifficultyLookupCache
         {
             string host = (Environment.GetEnvironmentVariable("DB_HOST") ?? "localhost");
             string user = (Environment.GetEnvironmentVariable("DB_USER") ?? "root");
+            string port = (Environment.GetEnvironmentVariable("DB_PORT") ?? "3306");
 
-            var connection = new MySqlConnection($"Server={host};Database=osu;User ID={user};ConnectionTimeout=5;ConnectionReset=false;Pooling=true;");
+            var connection = new MySqlConnection($"Server={host};Port={port};Database=osu;User ID={user};ConnectionTimeout=5;ConnectionReset=false;Pooling=true;");
             await connection.OpenAsync();
 
             return connection;

--- a/BeatmapDifficultyLookupCache/Models/beatmap_difficulty_attribute.cs
+++ b/BeatmapDifficultyLookupCache/Models/beatmap_difficulty_attribute.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Dapper.Contrib.Extensions;
+
+namespace BeatmapDifficultyLookupCache.Models
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    [Serializable]
+    [Table("osu_beatmap_difficulty_attribs")]
+    public class beatmap_difficulty_attribute
+    {
+        [ExplicitKey]
+        public ushort attrib_id { get; set; }
+
+        public float value { get; set; }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-web/issues/8755

Queries `osu_beatmap_difficulty_attribs` instead of `osu_beatmap_difficulty`.

```
$ curl -X POST -H "Content-Type: application/json"
       -d '{ "beatmap_id": 129891, "ruleset_id": 0, "mods": [ { "acronym": "DT" } ] }'
       http://localhost:5001/attributes

{"star_rating":11.944700241088867,"max_combo":2385,"aim_difficulty":4.905179977416992,"speed_difficulty":6.378220081329346,"flashlight_difficulty":0.0,"slider_factor":0.9936619997024536,"approach_rate":10.33329963684082,"overall_difficulty":9.777779579162598}
```