### PR TITLE
Fallback incompleted attributes to returning just star rating

### DIFF
--- a/BeatmapDifficultyLookupCache/Controllers/AttributesController.cs
+++ b/BeatmapDifficultyLookupCache/Controllers/AttributesController.cs
@@ -19,7 +19,6 @@ namespace BeatmapDifficultyLookupCache.Controllers
         }
 
         [HttpPost]
-        public async Task<DifficultyAttributes?> Post([FromBody] DifficultyRequest request)
-            => await cache.GetDifficulty(request);
+        public Task<DifficultyAttributes> Post([FromBody] DifficultyRequest request) => cache.GetAttributes(request);
     }
 }

--- a/BeatmapDifficultyLookupCache/Controllers/RatingController.cs
+++ b/BeatmapDifficultyLookupCache/Controllers/RatingController.cs
@@ -18,7 +18,6 @@ namespace BeatmapDifficultyLookupCache.Controllers
         }
 
         [HttpPost]
-        public async Task<double> Post([FromBody] DifficultyRequest request) =>
-            (await cache.GetDifficulty(request)).StarRating;
+        public Task<double> Post([FromBody] DifficultyRequest request) => cache.GetDifficultyRating(request);
     }
 }

--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -47,7 +47,18 @@ namespace BeatmapDifficultyLookupCache
 
         private static long totalLookups;
 
-        public async Task<DifficultyAttributes> GetDifficulty(DifficultyRequest request)
+        public async Task<double> GetDifficultyRating(DifficultyRequest request)
+        {
+            if (request.BeatmapId == 0)
+                return 0;
+
+            if (useDatabase)
+                return await getDatabasedDifficulty(request);
+
+            return (await computeAttributes(request)).StarRating;
+        }
+
+        public async Task<DifficultyAttributes> GetAttributes(DifficultyRequest request)
         {
             if (request.BeatmapId == 0)
                 return empty_attributes;
@@ -62,8 +73,7 @@ namespace BeatmapDifficultyLookupCache
                 {
                     // Databased attribute retrieval can fail if the database doesn't contain all attributes for a given beatmap.
                     // If such a case occurs, fall back to providing just the star rating rather than outputting exceptions.
-                    float starRating = await getDatabasedDifficulty(request);
-                    return new DifficultyAttributes { StarRating = starRating };
+                    return new DifficultyAttributes { StarRating = await GetDifficultyRating(request) };
                 }
             }
 


### PR DESCRIPTION
Resolves exceptions being spewed out in https://github.com/ppy/osu-beatmap-difficulty-lookup-cache/pull/5.

- If the database doesn't contain all expected attributes, it will fall back to returning just the star rating (`{"star_rating":7.523819923400879,"max_combo":0}`).
- For the `/rating` route, star difficulty returned via the `osu_beatmap_difficulty` table. Fixes potential overhead issue brought up in https://github.com/ppy/osu-beatmap-difficulty-lookup-cache/pull/5#issuecomment-1094169672