### PR TITLE
🔥 Remove unnecessary bloat in Docker image

### DIFF
--- a/BeatmapDifficultyLookupCache/Dockerfile
+++ b/BeatmapDifficultyLookupCache/Dockerfile
@@ -8,6 +8,8 @@ RUN dotnet restore
 # Copy everything else and build
 COPY . ./
 RUN dotnet publish -c Release -o out
+# get rid of bloat
+RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll ./out/osuTK.dll
 
 # Build runtime image
 FROM mcr.microsoft.com/dotnet/aspnet:6.0


### PR DESCRIPTION
These files are massive and unused in a headless context. Same workaround as applied in osu-difficulty-calculator. Seems to run fine.