### PR TITLE
Add support for arm64/apple silicon

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           context: ./BeatmapDifficultyLookupCache
           file: ./BeatmapDifficultyLookupCache/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/BeatmapDifficultyLookupCache/Dockerfile
+++ b/BeatmapDifficultyLookupCache/Dockerfile
@@ -15,4 +15,7 @@ RUN rm -rf ./out/runtimes ./out/osu.Game.Resources.dll
 FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
 COPY --from=build-env /app/out .
-ENTRYPOINT ["dotnet", "BeatmapDifficultyLookupCache.dll"]
+COPY docker docker
+
+# see https://github.com/dotnet/runtime/issues/66707 for issue handling signals on arm64
+ENTRYPOINT ["/app/docker/wait_term.sh", "BeatmapDifficultyLookupCache.dll"]

--- a/BeatmapDifficultyLookupCache/docker/wait_term.sh
+++ b/BeatmapDifficultyLookupCache/docker/wait_term.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# based on https://unix.stackexchange.com/questions/146756/forward-sigterm-to-child-in-bash/444676#444676
+prep_term()
+{
+    unset term_child_pid
+    unset term_kill_needed
+    trap 'handle_term' TERM INT
+}
+
+handle_term()
+{
+    if [ "${term_child_pid}" ]; then
+        kill -TERM "${term_child_pid}" 2>/dev/null
+    else
+        term_kill_needed="yes"
+    fi
+}
+
+wait_term()
+{
+    term_child_pid=$!
+    if [ "${term_kill_needed}" ]; then
+        kill -TERM "${term_child_pid}" 2>/dev/null
+    fi
+    wait ${term_child_pid} 2>/dev/null
+    trap - TERM INT
+    wait ${term_child_pid} 2>/dev/null
+}
+
+prep_term
+dotnet "$@" &
+wait_term


### PR DESCRIPTION
When running osu-web on my M1, I noticed that this repo was being emulated:

<img width="644" alt="image" src="https://github.com/ppy/osu-beatmap-difficulty-lookup-cache/assets/1329837/12a0408d-faef-419c-94c3-d44cca3f1462">

This fixes that.

The `wait_term` script has been taken from https://github.com/ppy/osu-elastic-indexer/blob/master/osu.ElasticIndexer/docker/wait_term.sh