### PR TITLE
Update packages

### DIFF
--- a/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
+++ b/BeatmapDifficultyLookupCache/BeatmapDifficultyLookupCache.csproj
@@ -6,14 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.35" />
+      <PackageReference Include="Dapper" Version="2.1.66" />
       <PackageReference Include="Dapper.Contrib" Version="2.0.78" />
-      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
-      <PackageReference Include="ppy.osu.Game" Version="2024.1104.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1104.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1104.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1104.0" />
-      <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1104.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.13" />
+      <PackageReference Include="ppy.osu.Game" Version="2025.304.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2025.304.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2025.304.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2025.304.0" />
+      <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2025.304.0" />
       <PackageReference Include="ppy.osu.Server.OsuQueueProcessor" Version="2024.1111.0" />
     </ItemGroup>
 


### PR DESCRIPTION
Most importantly, this bumps game packages, doing which has a high probability of fixing https://github.com/ppy/osu-web/issues/11982 in my opinion - the last diffcalc deploy definitely removed at least one attribute in every ruleset, and them suddenly becoming missing would for sure trigger the following code path:

https://github.com/ppy/osu-beatmap-difficulty-lookup-cache/blob/67ca69e759fc7a3205bc2ec301cdd0db02e3c0de/BeatmapDifficultyLookupCache/DifficultyCache.cs#L73-L75

which seems quite dubious to me in general (zero logging? at all???)

I'm somewhat nervous that this could have caused further downstream breakage, but I don't have good enough knowledge of what is using this service (other than the one specific broken osu-web endpoint) to figure that part out.