### PR TITLE
Fix incorrect retrieval of difficulty attributes for osu! ruleset with Hidden mod

### DIFF
--- a/BeatmapDifficultyLookupCache/DifficultyCache.cs
+++ b/BeatmapDifficultyLookupCache/DifficultyCache.cs
@@ -297,7 +297,7 @@ namespace BeatmapDifficultyLookupCache
                     case "FL" when rulesetId == 0:
                         return LegacyMods.Flashlight;
 
-                    case "HD" when rulesetId == 0 && mods.Any(m => m.Acronym == "FL"):
+                    case "HD" when rulesetId == 0:
                         return LegacyMods.Hidden;
 
                     case "TD" when rulesetId == 0:


### PR DESCRIPTION
Since https://github.com/ppy/osu/pull/31351, Hidden affects star rating on its own, not only in conjunction with Flashlight like before.

See also: https://github.com/ppy/osu-queue-score-statistics/pull/333.